### PR TITLE
Fix description generation

### DIFF
--- a/src/utils/getDescription.ts
+++ b/src/utils/getDescription.ts
@@ -2,7 +2,7 @@ import type { CollectionEntry } from "astro:content";
 
 export const getDescription = (post: CollectionEntry<"blog">) => {
   const body = post.body
-    .replace(/^#+\s/gm, "") // ヘッダーを削除
+    .replace(/^#+.*$/gm, "") // ヘッダー行を削除
     .replace(/\n/g, "") // 改行を削除
     .replace(/!\[.*?\]\(.*?\)/g, "") // 画像を削除
     .replace(/\[(.*?)\]\(.*?\)/g, "$1"); // リンクのURLを除外し、テキストのみを残す


### PR DESCRIPTION
## Summary
- remove entire header lines when generating post description

## Testing
- `npx run-s lint:*` *(fails: connect EHOSTUNREACH)*