### PR TITLE
Fix template strings in tag pages

### DIFF
--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -39,7 +39,7 @@ const { tag, posts } = Astro.props;
 <Layout title={`タグ: ${tag} | ${SITE_TITLE}`}>
   <Drawer>
     <Header />
-    <Main title={`タグ: ${tag}`} description=`タグ: ${tag}の記事一覧です。`>
+    <Main title={`タグ: ${tag}`} description={`タグ: ${tag}の記事一覧です。`}>
       {
         posts.map((post) => {
           return <PostCard post={post} />;

--- a/src/pages/tag/index.astro
+++ b/src/pages/tag/index.astro
@@ -13,7 +13,7 @@ const posts = await getPosts();
 const tags = getUniqueTags(posts);
 ---
 
-<Layout title=`タグ一覧 | ${SITE_TITLE}`>
+<Layout title={`タグ一覧 | ${SITE_TITLE}`}>
   <Drawer>
     <Header />
     <Main title="タグ一覧" description="当ブログで使用されているタグ一覧です。">


### PR DESCRIPTION
## Summary
- correct attribute interpolation on tag index page
- fix description expression for individual tag pages

## Testing
- `npm run lint` *(fails: run-s not found)*
- `npx pnpm lint` *(fails: cannot download pnpm)*